### PR TITLE
Fix nuget dependency

### DIFF
--- a/TickSpec/TickSpec.fsproj.paket.template
+++ b/TickSpec/TickSpec.fsproj.paket.template
@@ -10,3 +10,6 @@ requireLicenseAcceptance false
 description Describe behaviour in plain text using the Gherkin business language, i.e. given, when, then. Easily execute the behaviour against matching F# tick methods (let ``tick method`` () = true) or attributed C# or F# methods.
 summary TickSpec is a lightweight Behaviour Driven Development (BDD) framework for .Net.
 tags BDD C# F# .Net
+
+dependencies
+    FSharp.Core >= 3.1.2.5


### PR DESCRIPTION
This pull request targets the configuration of the nuget created.

The problem was that paket takes the nuget configuration according to "how we want to build the project". However, we want to build project with older FSharp.Core. That does not mean that it will not work with a newer one. So, we should not prevent usage in projects with newer FSharp.Core.