### PR TITLE
Multiple scenarios with same name

### DIFF
--- a/TickSpec/Extensions.fs
+++ b/TickSpec/Extensions.fs
@@ -22,6 +22,16 @@ module internal Seq =
                     yield !latest
         }
 
+    /// Checks whether the length of a sequence is equal to the passed length
+    let rec isLengthExactly length source =
+        if length < 0 then false
+        else if length = 0 then
+            if source |> Seq.isEmpty then true else false
+        else if source |> Seq.isEmpty then false
+        else
+            source |> Seq.tail |> isLengthExactly (length - 1)
+
+
  module internal TextReader =
     /// Reads lines from TextReader
     let readLines (reader:System.IO.TextReader) =

--- a/TickSpec/FeatureParser.fs
+++ b/TickSpec/FeatureParser.fs
@@ -107,6 +107,14 @@ let parseFeature (lines:string[]) =
 
     let scenarios =
         parsedFeatureBlocks.Scenarios
+        |> Seq.groupBy (fun s -> s.Name)
+        |> Seq.collect (fun (_,scenarios) ->
+            if scenarios |> Seq.isLengthExactly 1 then
+                scenarios
+            else
+                scenarios |> Seq.mapi (fun i s ->
+                    let newName = sprintf "%s~%d" s.Name (i+1)
+                    { s with Name = newName }))
         |> Seq.collect (fun scenario ->
             let examples = scenario.Examples @ sharedExamples
             let baseTags = parsedFeatureBlocks.Tags @ scenario.Tags

--- a/TickSpec/TickSpec.fsproj
+++ b/TickSpec/TickSpec.fsproj
@@ -39,7 +39,7 @@
     <Compile Include="TickSpec.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net452' " />
+    <PackageReference Include="FSharp.Core" Version="4.2.3" Condition=" '$(TargetFramework)' == 'net452' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Returning the functionality before modifying the parser. Before my changes, if there were multiple scenarios with the same name, it appended to their name index (after tilda). This was not implemented while changing the parser. So, I have added the functionality there.