### PR TITLE
Enable .NET Framework features again.

### DIFF
--- a/TickSpec/FeatureGen.fs
+++ b/TickSpec/FeatureGen.fs
@@ -1,6 +1,6 @@
 ﻿namespace TickSpec
 
-#if NET45
+#if !NETSTANDARD2_0
 open System
 open System.Collections.Generic
 open System.Diagnostics

--- a/TickSpec/ScenarioGen.fs
+++ b/TickSpec/ScenarioGen.fs
@@ -1,6 +1,6 @@
 ﻿module internal TickSpec.ScenarioGen
 
-#if NET45
+#if !NETSTANDARD2_0
 open System
 open System.Collections.Generic
 open System.Reflection

--- a/TickSpec/TickSpec.fs
+++ b/TickSpec/TickSpec.fs
@@ -204,7 +204,7 @@ type StepDefinitions (givens,whens,thens,events,valueParsers) =
     member __.GenerateFeature (sourceUrl:string,lines:string[]) =
         let featureSource = parseFeature lines
         let feature = featureSource.Name
-#if NET45
+#if !NETSTANDARD2_0
         let gen = FeatureGen(featureSource.Name,sourceUrl)
         let genType scenario =
             let lines =


### PR DESCRIPTION
The .NET Framework features (ScenarioGen and FeatureGen) were commented out for .NET Core but the used definition was missing for .NET Framework. So, the code was actually never used. This is returning it back.