### PR TITLE
Allow Tables and Functional Injection to be used together

### DIFF
--- a/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj
+++ b/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj
@@ -19,6 +19,8 @@
     <Compile Include="Room.fs" />
     <Compile Include="Computer.fs" />
     <EmbeddedResource Include="ComputerHeating.feature" />
+    <Compile Include="WalletSteps.fs" />
+    <EmbeddedResource Include="Wallet.feature" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TickSpec\TickSpec.fsproj" />

--- a/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj
+++ b/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj
@@ -14,7 +14,6 @@
     <Compile Include="DogSteps.fs" />
     <Compile Include="BowlSteps.fs" />
     <Compile Include="FeedingSteps.fs" />
-    <Compile Include="Wallet.fs" />
     <EmbeddedResource Include="Shopping.feature" />
     <Compile Include="ShoppingSteps.fs" />
     <Compile Include="Room.fs" />

--- a/Examples/ByFeature/FunctionalInjection/Shopping.feature
+++ b/Examples/ByFeature/FunctionalInjection/Shopping.feature
@@ -2,18 +2,23 @@
 
 This sample demonstrates the usage of Tables, Lists and Doc Strings with Functional Injection.
 
-Scenario: Making a purchase
-  Given the 2018 product catalog:
+Background: The product catalog is updated each year
+  Given no catalogs prior to 2018
+  And the 2018 product catalog:
     |Id |Description |Price|
     |123|Black Jumper|5    |
     |456|Blue Jeans  |10   |
-  When I make an order:
+  And the 2019 product catalog:
+    |Id |Description |Price|
+    |789|Red Socks   |3    |
+    |876|Sunglasses  |55   |
+
+Scenario: Making a purchase
+  When I make a purchase on 2018-12-22:
     * Blue Jeans
     * Black Jumper
   Then the receipt dated 2018-12-22 includes:
       """
-      Thankyou for your purchase.
-       - Black Jumper: $5.00
-       - Blue Jeans: $10.00
-      Total: $15.00
+      Blue Jeans: $10.00
+      Black Jumper: $5.00
       """

--- a/Examples/ByFeature/FunctionalInjection/Shopping.feature
+++ b/Examples/ByFeature/FunctionalInjection/Shopping.feature
@@ -1,7 +1,19 @@
 ﻿Feature: Shopping
 
-Scenario: Shopping in a store
-Given I have 100 dollars in my wallet
-When I buy an item for 5 dollars
-And I buy an item for 10 dollars
-Then My wallet contains 85 dollars
+This sample demonstrates the usage of Tables, Lists and Doc Strings with Functional Injection.
+
+Scenario: Making a purchase
+  Given the 2018 product catalog:
+    |Id |Description |Price|
+    |123|Black Jumper|5    |
+    |456|Blue Jeans  |10   |
+  When I make an order:
+    * Blue Jeans
+    * Black Jumper
+  Then the receipt dated 2018-12-22 includes:
+      """
+      Thankyou for your purchase.
+       - Black Jumper: $5.00
+       - Blue Jeans: $10.00
+      Total: $15.00
+      """

--- a/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
+++ b/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
@@ -31,7 +31,7 @@ let [<When>] ``I make a purchase on (.*):`` (purchaseDate: DateTime) (orderItems
 
 // DocString is passed as a regular string following captures
 let [<Then>] ``the receipt dated (.+) includes:`` (expectedDate: DateTime) (expected: string) (receipt: Receipt) =
-    let expectedLines = expected.Split('\n') |> Array.map(fun s -> s.Trim())
+    let expectedLines = expected.Split('\n')
     let Receipt(Date=receiptDate; Lines=receiptLines) = receipt
     Assert.AreEqual(expectedDate, receiptDate)
     Assert.AreEqual(expectedLines, receiptLines)

--- a/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
+++ b/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
@@ -23,9 +23,9 @@ let [<Given>] ``the (.+) product catalog:`` (yearInt: int) (items: CatalogItem[]
 let [<When>] ``I make a purchase on (.*):`` (purchaseDate: DateTime) (orderItems: string[]) (catalogs: Catalogs) =
     let Catalog(Items=catalogItems) = catalogs |> Map.find (Year purchaseDate.Year)
     let receiptLines = [|
-        for orderItem in orderItems do
+        for orderItem in orderItems ->
             let catalogItem = Array.find (fun x -> x.Description = orderItem) catalogItems
-            yield sprintf "%s: $%.2f" catalogItem.Description catalogItem.Price
+            sprintf "%s: $%.2f" catalogItem.Description catalogItem.Price
     |]
     Receipt(purchaseDate, receiptLines)
 

--- a/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
+++ b/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
@@ -31,7 +31,7 @@ let [<When>] ``I make a purchase on (.*):`` (purchaseDate: DateTime) (orderItems
 
 // DocString is passed as a regular string following captures
 let [<Then>] ``the receipt dated (.+) includes:`` (expectedDate: DateTime) (expected: string) (receipt: Receipt) =
-    let expectedLines = expected.Split('\n')
+    let expectedLines = expected.Split([|Environment.NewLine|], StringSplitOptions.RemoveEmptyEntries)
     let Receipt(Date=receiptDate; Lines=receiptLines) = receipt
     Assert.AreEqual(expectedDate, receiptDate)
     Assert.AreEqual(expectedLines, receiptLines)

--- a/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
+++ b/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
@@ -22,10 +22,11 @@ let [<Given>] ``the (.+) product catalog:`` (yearInt: int) (items: CatalogItem[]
 // Bullet list is bound to string[]
 let [<When>] ``I make a purchase on (.*):`` (purchaseDate: DateTime) (orderItems: string[]) (catalogs: Catalogs) =
     let Catalog(Items=catalogItems) = catalogs |> Map.find (Year purchaseDate.Year)
-    let receiptLines =
-        orderItems
-        |> Array.map (fun x -> catalogItems |> Array.find (fun y -> y.Description = x))
-        |> Array.map (fun x -> sprintf "%s: $%.2f" x.Description x.Price)
+    let receiptLines = [|
+        for orderItem in orderItems do
+            let catalogItem = Array.find (fun x -> x.Description = orderItem) catalogItems
+            yield sprintf "%s: $%.2f" catalogItem.Description catalogItem.Price
+    |]
     Receipt(purchaseDate, receiptLines)
 
 // DocString is passed as a regular string following captures

--- a/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
+++ b/Examples/ByFeature/FunctionalInjection/ShoppingSteps.fs
@@ -3,15 +3,32 @@
 open NUnit.Framework
 open TickSpec
 
-type Wallet = WalletDollars of int
+type CatalogItem = {Id: int; Description: string; Price: decimal}
+type Catalog = Catalog of Season:string * Items:(CatalogItem [])
+type Order = Order of string[]
+type Receipt = Receipt of string
 
-let [<Given>] ``I have (.*) dollars in my wallet`` (amount:int) =
-    WalletDollars amount // The output of function gets stored by type
+// Table parameters can be bound to record type arrays
+let [<Given>] ``the (.+) product catalog:`` (season: string) (rows: CatalogItem[]) =
+    Catalog(season, rows) // Available to later steps
 
-// Extra parameters are restored from store by its type, in this case it is the wallet
-let [<When>] ``I buy an item for (.*) dollars`` cost (WalletDollars wallet) =
-    // Wallet value is replaced in store thanks to this output
-    WalletDollars (wallet - cost)
+// Bullet list is bound to string[]
+let [<When>] ``I make an order:`` (orderItems: string[]) (catalog: Catalog) =
+    let receipt =
+        """
+        Thankyou for your purchase.
+          - Black Jumper: $5.00
+          - Blue Jeans: $10.00
+        Total: $15.00
+        """
+    (Order orderItems, Receipt receipt) // tuple elements will be injected separately in the next step
 
-let [<Then>] ``My wallet contains (.*) dollars`` (amount:int) (WalletDollars wallet) =
-    Assert.AreEqual(amount, wallet)
+// DocString is passed as a regular string following captures
+let [<Then>] ``the receipt dated (.+) includes:``
+        (receiptDate: string)   // captured
+        (expected: string)      // doc string
+        (Receipt actual)        // Injected from tuple element
+        (catalog: Catalog) =    // Injected from original Step Method
+
+    for line in expected.Split('\n') do
+        Assert.True(actual.Contains(line))

--- a/Examples/ByFeature/FunctionalInjection/Wallet.feature
+++ b/Examples/ByFeature/FunctionalInjection/Wallet.feature
@@ -1,0 +1,7 @@
+﻿Feature: Shopping
+
+Scenario: Shopping in a store
+Given I have 100 dollars in my wallet
+When I buy an item for 5 dollars
+And I buy an item for 10 dollars
+Then My wallet contains 85 dollars

--- a/Examples/ByFeature/FunctionalInjection/Wallet.fs
+++ b/Examples/ByFeature/FunctionalInjection/Wallet.fs
@@ -1,3 +1,0 @@
-﻿module Wallet
-
-type Wallet = WalletDollars of int

--- a/Examples/ByFeature/FunctionalInjection/WalletSteps.fs
+++ b/Examples/ByFeature/FunctionalInjection/WalletSteps.fs
@@ -1,0 +1,17 @@
+﻿module WalletSteps
+
+open NUnit.Framework
+open TickSpec
+
+type Wallet = WalletDollars of int
+
+let [<Given>] ``I have (.*) dollars in my wallet`` (amount:int) =
+    WalletDollars amount // The output of function gets stored by type
+
+// Extra parameters are restored from store by its type, in this case it is the wallet
+let [<When>] ``I buy an item for (.*) dollars`` cost (WalletDollars wallet) =
+    // Wallet value is replaced in store thanks to this output
+    WalletDollars (wallet - cost)
+
+let [<Then>] ``My wallet contains (.*) dollars`` (amount:int) (WalletDollars wallet) =
+    Assert.AreEqual(amount, wallet)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The following conversions are supported:
  - `Enum` types
  - `Union` types with no parameters
  - `Nullable<T>` types where the inner `T` type can be converted from `string`
- - F# Tuple types where each element can be converted from `string`
+ - `Tuple` types where each element can be converted from `string`
  - Array types `T []` where `T` can be converted from `string` and the original `string` is comma delimited
  - Types supported by `System.Convert.ChangeType`
 

--- a/TickSpec/ScenarioGen.fs
+++ b/TickSpec/ScenarioGen.fs
@@ -411,7 +411,7 @@ let defineStepMethod
                     gen.Emit(OpCodes.Throw)
             else
                 let ci = typeof<ArgumentException>.GetConstructor([|typeof<string>;typeof<string>|])
-                gen.Emit(OpCodes.Ldstr, sprintf "Expected a Table or array argument at position %d" (args.Length))
+                gen.Emit(OpCodes.Ldstr, sprintf "Expected a Table or array argument at position %d" args.Length)
                 gen.Emit(OpCodes.Ldstr, p.Name)
                 gen.Emit(OpCodes.Newobj, ci)
                 gen.Emit(OpCodes.Throw)

--- a/TickSpec/ScenarioGen.fs
+++ b/TickSpec/ScenarioGen.fs
@@ -386,13 +386,13 @@ let defineStepMethod
         gen.Emit(OpCodes.Ldloc, local)
     )
 
-    // Emit bullets argument
-    line.Bullets |> Option.iter (fun x ->
-        let t = (ps.[ps.Length-1].ParameterType)
-        emitArray gen providerField parsers t x
-    )
-    // Emit table argument
     if ps.Length > args.Length then
+        // Emit bullets argument
+        line.Bullets |> Option.iter (fun x ->
+            let t = (ps.[args.Length].ParameterType)
+            emitArray gen providerField parsers t x
+        )
+        // Emit table argument
         line.Table |> Option.iter (fun table ->
             let p = ps.[args.Length]
             let t = p.ParameterType

--- a/TickSpec/ScenarioRun.fs
+++ b/TickSpec/ScenarioRun.fs
@@ -135,14 +135,16 @@ let invokeStep
     let tail =
         match bullets,table,doc with
         | Some xs,None,None ->
-            let p = ps.[ps.Length-1]
-            let t = p.ParameterType.GetElementType()
+            let p = if ps.Length > args.Length then ps.[args.Length].ParameterType
+                    else failwithf "Expected an array argument at position %d" (args.Length)
+            let t = p.GetElementType()
             [|box (toArray parsers provider t xs)|]
         | None,Some table,None ->
-            let p = ps.[ps.Length-1].ParameterType
+            let p = if ps.Length > args.Length then ps.[args.Length].ParameterType
+                    else failwithf "Expected a Table or array argument at position %d" (args.Length)
             if p = typeof<Table> then [|box table|]
             elif p.IsArray then [|convertTable parsers provider p table|]
-            else failwith "Expecting table argument"
+            else failwithf "Expected a Table or array argument at position %d" (args.Length)
         | None,None,Some doc -> [|box doc|]
         | _,_,_ -> [||]
     let args = 

--- a/TickSpec/ScenarioRun.fs
+++ b/TickSpec/ScenarioRun.fs
@@ -136,15 +136,15 @@ let invokeStep
         match bullets,table,doc with
         | Some xs,None,None ->
             let p = if ps.Length > args.Length then ps.[args.Length].ParameterType
-                    else failwithf "Expected an array argument at position %d" (args.Length)
+                    else failwithf "Expected an array argument at position %d" args.Length
             let t = p.GetElementType()
             [|box (toArray parsers provider t xs)|]
         | None,Some table,None ->
             let p = if ps.Length > args.Length then ps.[args.Length].ParameterType
-                    else failwithf "Expected a Table or array argument at position %d" (args.Length)
+                    else failwithf "Expected a Table or array argument at position %d" args.Length
             if p = typeof<Table> then [|box table|]
             elif p.IsArray then [|convertTable parsers provider p table|]
-            else failwithf "Expected a Table or array argument at position %d" (args.Length)
+            else failwithf "Expected a Table or array argument at position %d" args.Length
         | None,None,Some doc -> [|box doc|]
         | _,_,_ -> [||]
     let args = 

--- a/TickSpec/ScenarioRun.fs
+++ b/TickSpec/ScenarioRun.fs
@@ -133,21 +133,22 @@ let invokeStep
         )
     let args = buildArgs args
     let tail =
+        let getTailParameter() =
+            if ps.Length > args.Length then ps.[args.Length].ParameterType
+            else failwithf "Step Method %s requires %d parameters" meth.Name args.Length
         match bullets,table,doc with
         | Some xs,None,None ->
-            let p = if ps.Length > args.Length then ps.[args.Length].ParameterType
-                    else failwithf "Expected an array argument at position %d" args.Length
+            let p = getTailParameter()
             let t = p.GetElementType()
             [|box (toArray parsers provider t xs)|]
         | None,Some table,None ->
-            let p = if ps.Length > args.Length then ps.[args.Length].ParameterType
-                    else failwithf "Expected a Table or array argument at position %d" args.Length
+            let p = getTailParameter()
             if p = typeof<Table> then [|box table|]
             elif p.IsArray then [|convertTable parsers provider p table|]
             else failwithf "Expected a Table or array argument at position %d" args.Length
         | None,None,Some doc -> [|box doc|]
         | _,_,_ -> [||]
-    let args = 
+    let args =
         let stArgs = Array.append args tail
         let injectionArgs = 
             let pars = meth.GetParameters()


### PR DESCRIPTION
This PR addresses an issue where `Table` parameters cannot be used along side `Functional Injection` in the same step. The existing code assumed that the Table would always be the last argument, while also assuming that the trailing arguments would be injected.

This change puts the Table argument after the regex captures, leaving the
trailing arguments to be injected.

To test this change I modified the `Shopping.feature` and `ShoppingSteps.fs` files:

```gherkin
Feature: Shopping

Scenario: Shopping in a store
Given I have 100 dollars in my wallet
When I buy items:
  |Description|Amount|
  |Popcorn    |5     |
  |Tickets    |10    |
Then My wallet contains 85 dollars
```

```fsharp
type Wallet = WalletDollars of int

let [<Given>] ``I have (.*) dollars in my wallet`` (amount:int) =
    WalletDollars amount // The output of function gets stored by type

// Extra parameters are restored from store by its type, in this case it is the wallet
let [<When>] ``I buy items:`` (items: Table) (WalletDollars balance) =
    let total =
        items.Rows
        |> Seq.map(fun r -> r.[1])
        |> Seq.sumBy(Int32.Parse)

    // Wallet value is replaced in store thanks to this output
    WalletDollars (balance - total)

let [<Then>] ``My wallet contains (.*) dollars`` (amount:int) (WalletDollars wallet) =
    Assert.AreEqual(amount, wallet)
```

Before this commit, the tests would fail with:

```
Users/mbuhot/src/TickSpec> "/usr/local/share/dotnet/dotnet" test /Users/mbuhot/src/TickSpec/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj --configuration Release --no-build /bl:/var/folders/dz/7m2pdfrs66v5qqgnwcwl_sgr0000gn/T/tmpSJ3ltv.tmp.binlog (In: false, Out: false, Err: false)
/usr/local/share/dotnet/sdk/2.1.403/MSBuild.dll -nologo -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,/usr/local/share/dotnet/sdk/2.1.403/dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,/usr/local/share/dotnet/sdk/2.1.403/dotnet.dll -maxcpucount -nodereuse:false -property:Configuration=Release -property:VSTestNoBuild=true -target:VSTest -verbosity:m -verbosity:quiet /bl:/var/folders/dz/7m2pdfrs66v5qqgnwcwl_sgr0000gn/T/tmpSJ3ltv.tmp.binlog /Users/mbuhot/src/TickSpec/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj
Test run for /Users/mbuhot/src/TickSpec/Examples/ByFeature/FunctionalInjection/bin/Release/netcoreapp2.1/FunctionalInjection.dll(.NETCoreApp,Version=v2.1)
Microsoft (R) Test Execution Command Line Tool Version 15.8.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
Failed   Scenario: Shopping in a store
Error Message:
 System.Exception : Expecting table argument
Stack Trace:
   at TickSpec.ScenarioRun.invokeStep(IDictionary`2 parsers, IInstanceProvider provider, MethodInfo meth, String[] args, FSharpOption`1 bullets, FSharpOption`1 table, FSharpOption`1 doc) in /Users/mbuhot/src/TickSpec/TickSpec/ScenarioRun.fs:line 121
   at TickSpec.ScenarioRun.generate@174.Invoke(Tuple`3 tupledArg) in /Users/mbuhot/src/TickSpec/TickSpec/ScenarioRun.fs:line 177
   at Microsoft.FSharp.Collections.SeqModule.Iterate[T](FSharpFunc`2 action, IEnumerable`1 source)
   at TickSpec.ScenarioRun.generate[a,b](IEnumerable`1 events_0, IEnumerable`1 events_1, IEnumerable`1 events_2, IEnumerable`1 events_3, IDictionary`2 parsers, a scenario, IEnumerable`1 lines, FSharpRef`1 serviceProviderFactory, Unit unitVar0) in /Users/mbuhot/src/TickSpec/TickSpec/ScenarioRun.fs:line 174
   at <StartupCode$TickSpec>.$TickSpec.action@185.Invoke(Unit arg40@) in /Users/mbuhot/src/TickSpec/TickSpec/TickSpec.fs:line 185
   at <StartupCode$TickSpec>.$TickSpec.GenerateScenarios@187-1.Invoke() in /Users/mbuhot/src/TickSpec/TickSpec/TickSpec.fs:line 187
   at NUnit.TickSpec.FeatureFixture.Bdd(Scenario scenario) in /Users/mbuhot/src/TickSpec/Examples/ByFeature/FunctionalInjection/NunitWiring.fs:line 16

Total tests: 6. Passed: 5. Failed: 1. Skipped: 0.
Test Run Failed.
Test execution time: 1.3179 Seconds
Test run for /Users/mbuhot/src/TickSpec/Examples/ByFeature/FunctionalInjection/bin/Release/net452/FunctionalInjection.dll(.NETFramework,Version=v4.5.2)
Microsoft (R) Test Execution Command Line Tool Version 15.8.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
Failed   Scenario: Shopping in a store
Error Message:
 System.ArgumentException : Expecting table or array argument
Parameter name: _arg1
Stack Trace:
  at Scenario: Shopping in a store.5: When I buy items: () [0x00000] in <3c9cff5a8252404ebbeab30a1d324eed>:0
  at Scenario: Shopping in a store.Run () [0x0000e] in <3c9cff5a8252404ebbeab30a1d324eed>:0
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <1010bb418d91488f8e6cc9deec6352ef>:0
--- End of stack trace from previous location where exception was thrown ---
  at NUnit.TickSpec+FeatureFixture.Bdd (TickSpec.Scenario scenario) [0x0005b] in <5c0dbae2291ad172a7450383e2ba0d5c>:0
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <1010bb418d91488f8e6cc9deec6352ef>:0

Total tests: 6. Passed: 5. Failed: 1. Skipped: 0.
Test Run Failed.
Test execution time: 1.4359 Seconds
Finished (Failed) 'DotNet:test' in 00:00:04.3213087
Finished (Failed) 'Test' in 00:00:19.1190369
```
