### PR TITLE
Support for async dispose

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fake-cli": {
-      "version": "5.20.4",
+      "version": "5.22.0",
       "commands": [
         "fake"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,9 +6,8 @@
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.2.3" Condition=" '$(ProjectExt)'=='.fsproj' AND '$(TargetFramework.StartsWith(net4))' " />
-    <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(ProjectExt)'=='.fsproj' AND '$(TargetFramework.StartsWith(net5))' " />
-    <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(ProjectExt)'=='.fsproj' AND '$(TargetFramework.StartsWith(netstandard))' " />
+    <PackageReference Include="FSharp.Core" Version="6.0.3" Condition=" '$(ProjectExt)'=='.fsproj' " />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <Authors>Phillip Trelford, Ruben Bartelink, Milos Chaloupka</Authors>
@@ -28,9 +27,11 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
+  <PropertyGroup>
+    <DotNetFrameworkVersion>net472</DotNetFrameworkVersion>
+    <DotNetStandardVersion>netstandard2.0</DotNetStandardVersion>
+    <DotNetCoreVersion>net6.0</DotNetCoreVersion>
+  </PropertyGroup>
   <ItemGroup>  
     <None Include="$(MSBuildThisFileDirectory)/LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
   </ItemGroup>

--- a/Examples/ByFeature/CustomContainer/CustomContainer.fsproj
+++ b/Examples/ByFeature/CustomContainer/CustomContainer.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="XunitAutofacWiring.fs" />

--- a/Examples/ByFeature/CustomContainer/CustomContainer.fsproj
+++ b/Examples/ByFeature/CustomContainer/CustomContainer.fsproj
@@ -14,11 +14,14 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\TickSpec\TickSpec.fsproj" />
     <ProjectReference Include="..\..\..\Wiring\TickSpec.Xunit\TickSpec.Xunit.fsproj" />
-    <PackageReference Include="Autofac" Version="4.8.1" />
-    <PackageReference Include="unquote" Version="4.0.0" />
-    <PackageReference Include="Xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
+    <PackageReference Include="unquote" Version="6.1.0" />
+    <PackageReference Include="Xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/Examples/ByFeature/DependencyInjection/DependencyInjection.fsproj
+++ b/Examples/ByFeature/DependencyInjection/DependencyInjection.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NunitWiring.fs" />

--- a/Examples/ByFeature/DependencyInjection/DependencyInjection.fsproj
+++ b/Examples/ByFeature/DependencyInjection/DependencyInjection.fsproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 </Project>

--- a/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj
+++ b/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NunitWiring.fs" />

--- a/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj
+++ b/Examples/ByFeature/FunctionalInjection/FunctionalInjection.fsproj
@@ -24,8 +24,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 </Project>

--- a/Examples/ByFeature/TaggedExamples/TaggedExamples.fsproj
+++ b/Examples/ByFeature/TaggedExamples/TaggedExamples.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />

--- a/Examples/ByFeature/TaggedExamples/TaggedExamples.fsproj
+++ b/Examples/ByFeature/TaggedExamples/TaggedExamples.fsproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 </Project>

--- a/Examples/ByFramework/CommandLine/CSharp/CSharp.csproj
+++ b/Examples/ByFramework/CommandLine/CSharp/CSharp.csproj
@@ -3,7 +3,7 @@
   <Import Project="../../../../netfx.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Feature.txt" />

--- a/Examples/ByFramework/CommandLine/FSharp/FSharp.fsproj
+++ b/Examples/ByFramework/CommandLine/FSharp/FSharp.fsproj
@@ -3,7 +3,7 @@
   <Import Project="../../../../netfx.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StockItem.fs" />

--- a/Examples/ByFramework/CommandLine/TicTacToe/TicTacToe.fsproj
+++ b/Examples/ByFramework/CommandLine/TicTacToe/TicTacToe.fsproj
@@ -3,7 +3,7 @@
   <Import Project="../../../../netfx.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="TicTacToeXO.txt" />

--- a/Examples/ByFramework/Expecto/FSharp.Expecto/Expecto.FSharp.fsproj
+++ b/Examples/ByFramework/Expecto/FSharp.Expecto/Expecto.FSharp.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../../netfx.props" />
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DotNetCoreVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>False</GenerateProgramFile>
   </PropertyGroup>

--- a/Examples/ByFramework/Expecto/FSharp.Expecto/Expecto.FSharp.fsproj
+++ b/Examples/ByFramework/Expecto/FSharp.Expecto/Expecto.FSharp.fsproj
@@ -22,8 +22,8 @@
     <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Expecto" Version="8.6.0" />
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Expecto" Version="9.0.4" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.12.13" />
   </ItemGroup>
 </Project>

--- a/Examples/ByFramework/MSTest/MSTest.FSharp/MSTest.FSharp.fsproj
+++ b/Examples/ByFramework/MSTest/MSTest.FSharp/MSTest.FSharp.fsproj
@@ -12,9 +12,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/Examples/ByFramework/MSTest/MSTest.FSharp/MSTest.FSharp.fsproj
+++ b/Examples/ByFramework/MSTest/MSTest.FSharp/MSTest.FSharp.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MSTestWiring.fs" />

--- a/Examples/ByFramework/NUnit/CSharp.NUnit/NUnit.CSharp.csproj
+++ b/Examples/ByFramework/NUnit/CSharp.NUnit/NUnit.CSharp.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Stock.feature" />

--- a/Examples/ByFramework/NUnit/CSharp.NUnit/NUnit.CSharp.csproj
+++ b/Examples/ByFramework/NUnit/CSharp.NUnit/NUnit.CSharp.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 </Project>

--- a/Examples/ByFramework/NUnit/FSharp.NUnit/NUnit.FSharp.fsproj
+++ b/Examples/ByFramework/NUnit/FSharp.NUnit/NUnit.FSharp.fsproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 </Project>

--- a/Examples/ByFramework/NUnit/FSharp.NUnit/NUnit.FSharp.fsproj
+++ b/Examples/ByFramework/NUnit/FSharp.NUnit/NUnit.FSharp.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FeatureFixture.fs" />

--- a/Examples/ByFramework/xUnit/FSharp.xUnit/Xunit.FSharp.fsproj
+++ b/Examples/ByFramework/xUnit/FSharp.xUnit/Xunit.FSharp.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Retail.fs" />

--- a/Examples/ByFramework/xUnit/FSharp.xUnit/Xunit.FSharp.fsproj
+++ b/Examples/ByFramework/xUnit/FSharp.xUnit/Xunit.FSharp.fsproj
@@ -16,9 +16,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\TickSpec\TickSpec.fsproj" />
     <ProjectReference Include="..\..\..\..\Wiring\TickSpec.Xunit\TickSpec.Xunit.fsproj" />
-    <PackageReference Include="Xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/Examples/ByStyle/Attributes/Attributes.fsproj
+++ b/Examples/ByStyle/Attributes/Attributes.fsproj
@@ -38,8 +38,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 </Project>

--- a/Examples/ByStyle/Attributes/Attributes.fsproj
+++ b/Examples/ByStyle/Attributes/Attributes.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="ReadMe.txt" />

--- a/Examples/ByStyle/Functional/Functional.fsproj
+++ b/Examples/ByStyle/Functional/Functional.fsproj
@@ -18,8 +18,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 </Project>

--- a/Examples/ByStyle/Functional/Functional.fsproj
+++ b/Examples/ByStyle/Functional/Functional.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Functional.fs" />

--- a/Examples/ByStyle/Interactive/Interactive.fsproj
+++ b/Examples/ByStyle/Interactive/Interactive.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StoryRunner.fs" />

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Example video: http://www.youtube.com/watch?v=UuTL3nj9fIE
 
 Simply reference TickSpec via [NuGet or Paket](https://www.nuget.org/packages/TickSpec/), download the assembly or build the project from source.
 
-- The binary should work cleanly on any .NET Standard 2.0, .NET 4.5 or later environment.
-- The TickSpec solution file works with Visual Studio 2017. 
+- The binary should work cleanly on any .NET Standard 2.0, .NET 4.7.2 or later environment.
+- The TickSpec solution file works with Visual Studio 2017 and newer (tested with VS 2022).
 - Historically, Silverlight was supported; this support and the related examples were removed in 2017 (but remain in the commit history for the archeologically inclined)
 - Useful samples are available in the Examples folder https://github.com/fsprojects/TickSpec/tree/master/Examples/ and depending your choice, this one is a good start : https://github.com/fsprojects/TickSpec/tree/master/Examples/ByFramework 
 

--- a/TickSpec.Tests/TickSpec.Tests.fsproj
+++ b/TickSpec.Tests/TickSpec.Tests.fsproj
@@ -12,9 +12,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/TickSpec.Tests/TickSpec.Tests.fsproj
+++ b/TickSpec.Tests/TickSpec.Tests.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="WithItems.feature" />

--- a/TickSpec.sln
+++ b/TickSpec.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32126.317
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{CD7A2701-42ED-47BD-8724-1E130B5C5071}"
 EndProject
@@ -33,11 +33,15 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Functional", "Examples\BySt
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "._", "._", "{51B6BE98-A176-4315-83F5-54800BC03EB4}"
 	ProjectSection(SolutionItems) = preProject
-		.travis.yml = .travis.yml
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
 		build.bat = build.bat
 		build.fsx = build.fsx
-		build.sh = build.sh
+		Directory.Build.props = Directory.Build.props
+		.config\dotnet-tools.json = .config\dotnet-tools.json
+		LICENSE.txt = LICENSE.txt
+		netfx.props = netfx.props
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md
 	EndProjectSection
@@ -54,7 +58,7 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "DependencyInjection", "Exam
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FunctionalInjection", "Examples\ByFeature\FunctionalInjection\FunctionalInjection.fsproj", "{1CE6B475-C94F-438E-97D4-5E99FD0F04D4}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TickSpec.Tests", "TickSpec.Tests\TickSpec.Tests.fsproj", "{CD2AA807-5E4F-4A2C-80F7-A7D7CA6B3C2D}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "TickSpec.Tests", "TickSpec.Tests\TickSpec.Tests.fsproj", "{CD2AA807-5E4F-4A2C-80F7-A7D7CA6B3C2D}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "TaggedExamples", "Examples\ByFeature\TaggedExamples\TaggedExamples.fsproj", "{39C63F8E-F3A5-48D8-851C-62BEB9C701C2}"
 EndProject
@@ -64,11 +68,11 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "MSTest.FSharp", "Examples\B
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Expecto", "Expecto", "{750A854A-FB45-4E51-94DF-D79B4F1E46DC}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Expecto.FSharp", "Examples\ByFramework\Expecto\FSharp.Expecto\Expecto.FSharp.fsproj", "{F9B139E4-0160-4150-B420-73DCCD57B6B8}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Expecto.FSharp", "Examples\ByFramework\Expecto\FSharp.Expecto\Expecto.FSharp.fsproj", "{F9B139E4-0160-4150-B420-73DCCD57B6B8}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Wiring", "Wiring", "{373B654A-3A88-48CC-A0A3-0454514E61FF}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TickSpec.Xunit", "Wiring\TickSpec.Xunit\TickSpec.Xunit.fsproj", "{DDB39875-AA8B-494E-B923-C8143930464F}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "TickSpec.Xunit", "Wiring\TickSpec.Xunit\TickSpec.Xunit.fsproj", "{DDB39875-AA8B-494E-B923-C8143930464F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/TickSpec/ServiceProvider.fs
+++ b/TickSpec/ServiceProvider.fs
@@ -26,6 +26,11 @@ type InstanceStore () =
                 distinctAddRec key value (head :: revHead) rest
         distinctAddRec key value [] inList
 
+    let disposeAsync (d:IAsyncDisposable) =
+        d.DisposeAsync()
+        |> ignore
+        ()
+
     /// Stores element (skips storing existing, old element removed and new prepended)
     member this.Store key value =
         instances <- instances |> distinctAdd key value
@@ -36,11 +41,13 @@ type InstanceStore () =
         | Some elem -> Some(snd elem)
         | None -> None
 
+
     interface IDisposable with
         member __.Dispose() =
             instances
             |> Seq.map snd
             |> Seq.iter (function
+                | :? IAsyncDisposable as d -> disposeAsync(d)
                 | :? IDisposable as d -> d.Dispose()
                 | _ -> ())
             instances <- []

--- a/TickSpec/TickSpec.fsproj
+++ b/TickSpec/TickSpec.fsproj
@@ -4,15 +4,10 @@
   <PropertyGroup>
     <TargetFrameworks>$(DotNetStandardVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
     <Title>TickSpec</Title>
-    <Description>
-      TickSpec is a lightweight Behaviour Driven Development (BDD) framework for .Net.
-      Describe behaviour in plain text using the Gherkin business language, i.e. Given,
-      When, Then. Easily execute the behaviour against matching F# 'ticked' methods 
-      (let ``tick method`` () = true) or attributed C# or F# methods.
-    </Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0"/>
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
@@ -31,5 +26,11 @@
     <Compile Include="FeatureParser.fs" />
     <Compile Include="Feature.fs" />
     <Compile Include="TickSpec.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 </Project>

--- a/TickSpec/TickSpec.fsproj
+++ b/TickSpec/TickSpec.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetStandardVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
     <Title>TickSpec</Title>
     <Description>
       TickSpec is a lightweight Behaviour Driven Development (BDD) framework for .Net.
@@ -11,6 +11,9 @@
       (let ``tick method`` () = true) or attributed C# or F# methods.
     </Description>
   </PropertyGroup>
+  <ItemGroup>
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0"/>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Extensions.fs" />

--- a/Wiring/TickSpec.Xunit/TickSpec.Xunit.fsproj
+++ b/Wiring/TickSpec.Xunit/TickSpec.Xunit.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>$(DotNetStandardVersion);$(DotNetFrameworkVersion)</TargetFrameworks>
     <Title>TickSpec.Xunit</Title>
     <Description>
       TickSpec integration with Xunit.

--- a/Wiring/TickSpec.Xunit/TickSpec.Xunit.fsproj
+++ b/Wiring/TickSpec.Xunit/TickSpec.Xunit.fsproj
@@ -18,6 +18,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\TickSpec\TickSpec.fsproj" />
-    <PackageReference Include="Xunit" Version="2.4.0" />
+    <PackageReference Include="Xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/build.fsx
+++ b/build.fsx
@@ -101,7 +101,7 @@ Target.create "Build" (fun _ ->
 Target.create "Test" (fun _ ->
     // Xunit seems to be failing under Linux with net452 runner, let's just skip it
     // the .NET 4 tests all together there
-    let framework = if Environment.isWindows then None else Some "net5.0"
+    let framework = if Environment.isWindows then None else Some "net6.0"
     let logger = if AppVeyor.detect () then "Appveyor" |> Some else None
 
     Sln

--- a/netfx.props
+++ b/netfx.props
@@ -20,6 +20,7 @@
     <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net462'">$(BaseFrameworkPathOverrideForMono)/4.6.2-api</FrameworkPathOverride>
     <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net47'">$(BaseFrameworkPathOverrideForMono)/4.7-api</FrameworkPathOverride>
     <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net471'">$(BaseFrameworkPathOverrideForMono)/4.7.1-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net472'">$(BaseFrameworkPathOverrideForMono)/4.7.2-api</FrameworkPathOverride>
     <EnableFrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != ''">true</EnableFrameworkPathOverride>
 
     <!-- Add the Facades directory.  Not sure how else to do this. Necessary at least for .NET 4.5 -->


### PR DESCRIPTION
# Updates
- Updating target dotnet framework to 4.7.2 since 4.5 will run out of support in few months.
- Updating target dotnet core to 6.0 since it is LTS.
- Updating fake-cli to latest version.
- Updating nugets used in all projects.
- Defining dotnet versions in Directory.Build.props and using it across all projects.
- Removing references to non-existing files in the .sln and adding references to the rest of solution items.
- Updating README (compatibility with VS 2022)
- Replacing TickSpec project description with reference to README (this will be used as description in the Nuget.org)

# Support for DisposeAsync
Adding support for asynchronously disposable resources in TickSpec/ServiceProvider.fs. This requires either using netstandard2.1 or dotnet6.0, or importing Microsoft.Bcl.AsyncInterfaces. At first I planned to use AsyncInterfaces only for net472 target framework and increase netstandard version to 2.1, but in netstandard2.1 there is no method MarkSequencePoint on ILGenerator (used in TickSpec/ScenarioGen.fs). (According to documentation this method doesn't exist even in netstandard2.0, but somehow it still works).