### PR TITLE
Issue #45: Improve execution time in large assemblies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 #### 2.0.3 (To be released)
-* [Feature] Makes `ScenarioInformation` available to step implementations through arguments resolution (issue #49)  
+* [Feature] Makes `ScenarioInformation` available to step implementations through arguments resolution (issue #49)
+* [Fix] Performance improvements when the used assembly contains many methods (issue #45)
 * [Fix] Keep empty lines in doc strings (issue #60)
 * [Fix] Allow multiple step types on a single method (issue #55)
 * [Fix] Unit test serialization to allow running from IDE easily

--- a/TickSpec/ScenarioGen.fs
+++ b/TickSpec/ScenarioGen.fs
@@ -481,10 +481,7 @@ let defineStepMethod
 let defineRunMethod
     (scenarioBuilder:TypeBuilder)
     (providerField:FieldBuilder)
-    (beforeScenarioEvents:MethodInfo list,
-     afterScenarioEvents:MethodInfo list,
-     beforeStepEvents:MethodInfo list,
-     afterStepEvents:MethodInfo list)
+    (beforeScenarioEvents,afterScenarioEvents,beforeStepEvents,afterStepEvents)
     (stepMethods:MethodBuilder seq) =
     /// Run method to execute all scenario steps
     let runMethod =
@@ -496,8 +493,8 @@ let defineRunMethod
     let gen = runMethod.GetILGenerator()
 
     // Emit event methods
-    let emitEvents (ms:MethodInfo seq) =
-        ms |> Seq.iter (fun mi ->
+    let emitEvents =
+        Seq.iter (fun (mi:MethodInfo) ->
             if mi.IsStatic then
                 gen.EmitCall(OpCodes.Call, mi, null)
             else

--- a/TickSpec/ScenarioGen.fs
+++ b/TickSpec/ScenarioGen.fs
@@ -481,11 +481,11 @@ let defineStepMethod
 let defineRunMethod
     (scenarioBuilder:TypeBuilder)
     (providerField:FieldBuilder)
-    (beforeScenarioEvents:MethodInfo seq,
-     afterScenarioEvents:MethodInfo seq,
-     beforeStepEvents:MethodInfo seq,
-     afterStepEvents:MethodInfo seq)
-    (stepMethods:seq<MethodBuilder>) =
+    (beforeScenarioEvents:MethodInfo list,
+     afterScenarioEvents:MethodInfo list,
+     beforeStepEvents:MethodInfo list,
+     afterStepEvents:MethodInfo list)
+    (stepMethods:MethodBuilder seq) =
     /// Run method to execute all scenario steps
     let runMethod =
         scenarioBuilder.DefineMethod("Run",

--- a/TickSpec/TickSpec.fs
+++ b/TickSpec/TickSpec.fs
@@ -88,6 +88,7 @@ type StepDefinitions (givens,whens,thens,events,valueParsers) =
             xs
             |> Seq.filter (fun m -> m |> isMethodInScope feature scenario)
             |> Seq.map (fun (_,_,_,e) -> e)
+            |> Seq.toList
         events
         |> fun (ea,eb,ec,ed) -> choose ea, choose eb, choose ec, choose ed
     new () =
@@ -144,7 +145,10 @@ type StepDefinitions (givens,whens,thens,events,valueParsers) =
             ) ([],[],[])
 
         let filter (t:Type) (elements:(string list * string list * string list * MethodInfo) seq) =
-            elements |> Seq.filter (fun (_,_,_,m) -> null <> Attribute.GetCustomAttribute(m,t))
+            elements
+            |> Seq.filter (fun (_,_,_,m) -> null <> Attribute.GetCustomAttribute(m,t))
+            |> Seq.toList
+
         /// Step events
         let events = methods |> filter typeof<EventAttribute>
         let beforeScenario = events |> filter typeof<BeforeScenarioAttribute>

--- a/TickSpec/TickSpec.fs
+++ b/TickSpec/TickSpec.fs
@@ -157,23 +157,24 @@ type StepDefinitions (givens,whens,thens,events,valueParsers) =
                         |> Array.tryFind (fun x -> x.IsAssignableFrom(usedType))
 
                     match correspondingAttrType with
+                    | None -> ()
                     // In case it is one of the ones we care about, we add it to the map
                     | Some attrType ->
-                        // We use caching to not repeatedly get the scope for methods or its declaring types
-                        if methodScope.ContainsKey mi |> not then
-                            let parentType = mi.DeclaringType
-                            if parentScope.ContainsKey parentType |> not then
-                                let parentScopeAttribute = parentType.GetCustomAttributes(typeof<StepScopeAttribute>,true)
-                                parentScope.[parentType] <- getScope parentScopeAttribute List.empty List.empty List.empty
-                            let parentTags, parentFeatures, parentScenarios = parentScope.[parentType]
-                            let methodScopeAttribute = mi.GetCustomAttributes(typeof<StepScopeAttribute>,true)
-                            methodScope.[mi] <- getScope methodScopeAttribute parentTags parentFeatures parentScenarios
+                    // We use caching to not repeatedly get the scope for methods or its declaring types
+                    if methodScope.ContainsKey mi |> not then
+                        let parentType = mi.DeclaringType
+                        if parentScope.ContainsKey parentType |> not then
+                            let parentScopeAttribute =
+                                parentType.GetCustomAttributes(typeof<StepScopeAttribute>,true)
+                            parentScope.[parentType] <- getScope parentScopeAttribute List.empty List.empty List.empty
+                        let parentTags, parentFeatures, parentScenarios = parentScope.[parentType]
+                        let methodScopeAttribute = mi.GetCustomAttributes(typeof<StepScopeAttribute>,true)
+                        methodScope.[mi] <- getScope methodScopeAttribute parentTags parentFeatures parentScenarios
 
-                        let tags, features, scenarios = methodScope.[mi]
+                    let tags, features, scenarios = methodScope.[mi]
 
-                        let existingPairs = attributeMap.[attrType]
-                        attributeMap.[attrType] <- ((tags, features, scenarios, mi), attr)::existingPairs
-                    | None -> ()
+                    let existingPairs = attributeMap.[attrType]
+                    attributeMap.[attrType] <- ((tags, features, scenarios, mi), attr)::existingPairs
                 )
             )
 

--- a/TickSpec/TickSpec.fs
+++ b/TickSpec/TickSpec.fs
@@ -182,15 +182,14 @@ type StepDefinitions (givens,whens,thens,events,valueParsers) =
 
         /// Step methods
         let extractStepAttribute stepAttribute =
-            categorizedMethods.[stepAttribute]
-            |> Seq.map (fun ((_,_,_,m) as method, attr) ->
-                let p =
-                    match (attr :?> StepAttribute).Step with
-                    | null -> m.Name
-                    | step -> step
-                p,method
-            )
-            |> Array.ofSeq
+            [| 
+                for _,_,_,m as method, attr in categorizedMethods[stepAttribute] ->
+                    let stepName =
+                        match (attr :?> StepAttribute).Step with
+                        | null -> m.Name
+                        | step -> step
+                    stepName, method
+            |]
 
         let givens = typeof<GivenAttribute> |> extractStepAttribute
         let whens = typeof<WhenAttribute> |> extractStepAttribute


### PR DESCRIPTION
The usage of `seq` caused the reflection to be done repetitively for all operations. I have improved the execution time of the tests in the provided project (see issue) from 12 seconds to 1.4 seconds just by making this tiny change of materializing the sequences into lists. I had to materialize it in two places:
* The moment where we filter out all methods that are attributed by one of the event attributes.
* The place where we select events in-scope for a given scenario